### PR TITLE
Renable nested title additions and amend test with frontmatter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,15 +490,15 @@ impl<'a> Exporter<'a> {
         // Most of the time, a reference triggers 5 events: [ or ![, [, <text>, ], ]
         let mut buffer = Vec::with_capacity(5);
 
-        // if self.add_titles {
-        //     // Ensure that each (possibly embedded) note starts with a reasonable top-level heading
-        //     let note_name = infer_note_title_from_path(path);
-        //     let h1_tag = Tag::Heading(HeadingLevel::H1, None, vec![]);
+        if self.add_titles {
+            // Ensure that each (possibly embedded) note starts with a reasonable top-level heading
+            let note_name = infer_note_title_from_path(path);
+            let h1_tag = Tag::Heading(HeadingLevel::H1, None, vec![]);
 
-        //     events.push(Event::Start(h1_tag.clone()));
-        //     events.push(Event::Text(note_name));
-        //     events.push(Event::End(h1_tag.clone()));
-        // }
+            events.push(Event::Start(h1_tag.clone()));
+            events.push(Event::Text(note_name));
+            events.push(Event::End(h1_tag.clone()));
+        }
 
         for event in Parser::new_ext(&content, parser_options) {
             if ref_parser.state == RefParserState::Resetting {

--- a/tests/testdata/expected/add-titles/Main note.md
+++ b/tests/testdata/expected/add-titles/Main note.md
@@ -1,3 +1,7 @@
+---
+title: Main note
+---
+
 # Main note
 
 # Sub note


### PR DESCRIPTION
The frontmatter changes broke the [add_titles](https://github.com/brandonkboswell/obsidian-export/blob/2df8647bd1afa9339250843376382585f659e6e7/tests/export_test.rs#L367) test

I haven't fully understood the changes you made but going purely off the test I assume you would prefer the result to be 

```
---
title: Main note
---

# Main note

# Sub note

# Sub sub note

No more notes
```

instead of 
```
---
title: Main note
---

No more notes
```

So I have made the code changes to achieve this and updated the expected [test result ](https://github.com/brandonkboswell/obsidian-export/blob/title_frontmatter/tests/testdata/expected/add-titles/Main%20note.md)

Btw the input file is [this](https://github.com/brandonkboswell/obsidian-export/blob/title_frontmatter/tests/testdata/input/add-titles/Main%20note.md)


Hope I understood your goal right, I'm just currently attempting to follow in your footsteps to publish a section of my obsidian vault but trying to codify your steps with a [Nix](https://nixos.org/) file and building a Rust packages in nix requires all tests to pass :D 
